### PR TITLE
Add missing condition from original polyfill

### DIFF
--- a/src/browser/ui/dom/components/ReactDOMInput.js
+++ b/src/browser/ui/dom/components/ReactDOMInput.js
@@ -60,8 +60,7 @@ function querySelectorAllPolyfill(r, c, i, j, a) {
   for (i = r.length; i--;) {
     s.addRule(r[i], 'k:v');
     for (j = a.length; j--;) {
-      a[j].currentStyle.k;
-      c.push(a[j]);
+      a[j].currentStyle.k && c.push(a[j]);
     }
     s.removeRule(0);
   }


### PR DESCRIPTION
The query selector polyfill was matching all elements on the page. Looks like the condition before the push was accidentally removed from the original found here http://www.codecouch.com/2012/05/adding-document-queryselectorall-support-to-ie-7/
